### PR TITLE
feat: adding Access-Control-Expose-Headers to global configuration

### DIFF
--- a/packages/core/src/@types/main.d.ts
+++ b/packages/core/src/@types/main.d.ts
@@ -33,6 +33,7 @@ interface Config {
     uiPort?: number;
     corsEnabled?: boolean;
     corsAllowOrigin?: string;
+    accessControlExposeHeaders?: string[];
 }
 
 interface Scenario {

--- a/packages/core/src/defaultconfig.json
+++ b/packages/core/src/defaultconfig.json
@@ -2,5 +2,6 @@
     "stubsPort": 4000,
     "uiPort": 3000,
     "corsEnabled": true,
-    "corsAllowedOrigin": "*"
+    "corsAllowedOrigin": "*",
+    "accessControlExposeHeaders": []
 }

--- a/packages/core/src/globals.d.ts
+++ b/packages/core/src/globals.d.ts
@@ -4,6 +4,7 @@ declare class Stubr {
         uiPort?: number;
         corsEnabled?: boolean;
         corsAllowOrigin?: string;
+        accessControlExposeHeaders?: string[];
     });
 
     register(scenario: {

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -425,6 +425,12 @@ class Stubr implements IStubr {
                         );
                         ctx.set('Access-Control-Allow-Methods', '*');
                         ctx.set('Access-Control-Allow-Headers', '*');
+                        ctx.set(
+                            'Access-Control-Expose-Headers',
+                            this.stubrConfig?.accessControlExposeHeaders?.length
+                                ? this.stubrConfig?.accessControlExposeHeaders.toString()
+                                : ''
+                        );
                         ctx.status = 200;
 
                         debug(

--- a/packages/core/src/utils/responseUtils.ts
+++ b/packages/core/src/utils/responseUtils.ts
@@ -64,6 +64,12 @@ const seedResponseWithCase = async (
             'Access-Control-Allow-Origin',
             config?.corsAllowOrigin ? config?.corsAllowOrigin : '*'
         );
+        ctx.set(
+            'Access-Control-Expose-Headers',
+            config?.accessControlExposeHeaders?.length
+                ? config?.accessControlExposeHeaders.toString()
+                : ''
+        );
     }
 
     ctx.status = selectedScenario.responseCode;


### PR DESCRIPTION
This feature adds the ability to add global custom headers to the response body, via config, when CORS is enabled.

See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers